### PR TITLE
fix(ui): standardize hero section pills background

### DIFF
--- a/Sora/Views/Base Views/HomeView.swift
+++ b/Sora/Views/Base Views/HomeView.swift
@@ -159,7 +159,8 @@ struct HomeView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
-                        .background(Color.white.opacity(0.2))
+                        .background(Color(red: 0.85, green: 0.85, blue: 0.85).opacity(0.5))
+                        .background(.ultraThinMaterial)
                         .clipShape(Capsule())
                     
                     if (hero.voteAverage ?? 0.0) > 0 {
@@ -175,7 +176,8 @@ struct HomeView: View {
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(Color.black.opacity(0.3))
+                        .background(Color(red: 0.85, green: 0.85, blue: 0.85).opacity(0.5))
+                        .background(.ultraThinMaterial)
                         .clipShape(Capsule())
                     }
                 }

--- a/Sora/Views/Base Views/HomeView.swift
+++ b/Sora/Views/Base Views/HomeView.swift
@@ -382,7 +382,7 @@ struct MediaSection: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text(title)
-                    .font(.title2)
+                    .font(.title3)
                     .fontWeight(.bold)
                     .foregroundColor(.primary)
                 

--- a/Sora/Views/View Elements/FeaturedCard.swift
+++ b/Sora/Views/View Elements/FeaturedCard.swift
@@ -18,90 +18,167 @@ struct FeaturedCard: View {
     }
     
     private var cardWidth: CGFloat {
-        isLarge ? 200 : 140
+        isLarge ? 250 : 140
     }
     
     private var cardHeight: CGFloat {
-        isLarge ? 280 : 210
+        isLarge ? 150 : 210
     }
     
     var body: some View {
         NavigationLink(destination: MediaDetailView(searchResult: result)) {
-            VStack(alignment: .leading, spacing: 0) {
-                ZStack(alignment: .bottomLeading) {
-                    KFImage(URL(string: result.fullBackdropURL ?? result.fullPosterURL ?? ""))
-                        .placeholder {
-                            FallbackImageView(
-                                isMovie: result.isMovie,
-                                size: CGSize(width: cardWidth, height: cardHeight * 0.75)
-                            )
-                        }
-                        .resizable()
-                        .aspectRatio(16/9, contentMode: .fill)
-                        .frame(width: cardWidth, height: cardHeight * 0.75)
-                        .clipped()
-                    
-                    LinearGradient(
-                        gradient: Gradient(stops: [
-                            .init(color: Color.clear, location: 0.0),
-                            .init(color: Color.black.opacity(0.3), location: 0.5),
-                            .init(color: Color.black.opacity(0.7), location: 1.0)
-                        ]),
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .frame(height: cardHeight * 0.4)
-                    
-                    VStack {
-                        HStack {
-                            Spacer()
-                            HStack(spacing: 2) {
-                                Image(systemName: "star.fill")
-                                    .font(.caption2)
-                                    .foregroundColor(.yellow)
-                                Text(String(format: "%.1f", result.voteAverage ?? 0.0))
-                                    .font(.caption2)
-                                    .fontWeight(.medium)
-                                    .foregroundColor(.white)
+            if isLarge {
+                VStack(alignment: .leading, spacing: 0) {
+                    ZStack(alignment: .bottomLeading) {
+                        KFImage(URL(string: result.fullBackdropURL ?? result.fullPosterURL ?? ""))
+                            .placeholder {
+                                FallbackImageView(
+                                    isMovie: result.isMovie,
+                                    size: CGSize(width: 250, height: 150)
+                                )
                             }
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 3)
-                            .background(Color.black.opacity(0.6))
-                            .clipShape(Capsule())
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 250, height: 150)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .clipped()
+                        
+                        // Overlay avec pilules mediatype et rating
+                        VStack {
+                            Spacer()
+                            HStack {
+                                HStack(spacing: 8) {
+                                    // Pilule mediatype
+                                    Text(result.isMovie ? "Movie" : "TV Show")
+                                        .font(.caption2)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.white)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .background(
+                                            Color(red: 0.62, green: 0.62, blue: 0.62).opacity(0.4)
+                                        )
+                                        .clipShape(Capsule())
+                                    
+                                    // Pilule rating
+                                    HStack(spacing: 2) {
+                                        Image(systemName: "star.fill")
+                                            .font(.caption2)
+                                            .foregroundColor(.yellow)
+                                        Text(String(format: "%.1f", result.voteAverage ?? 0.0))
+                                            .font(.caption2)
+                                            .fontWeight(.medium)
+                                            .foregroundColor(.white)
+                                    }
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        Color(red: 0.62, green: 0.62, blue: 0.62).opacity(0.4)
+                                    )
+                                    .clipShape(Capsule())
+                                }
+                                Spacer()
+                            }
+                            .padding(.leading, 10)
+                            .padding(.bottom, 10)
                         }
+                    }
+                    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                    
+                    // Titre positionné sous l'image
+                    HStack {
+                        Spacer()
+                            .frame(width: 8)  // Décalage de 8px à droite
+                        
+                        Text(result.displayTitle)
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(.white)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                        
                         Spacer()
                     }
-                    .padding(8)
+                    .padding(.top, 8)  // 8px en dessous de l'image
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(result.displayTitle)
-                        .font(isLarge ? .subheadline : .caption)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                        .foregroundColor(.primary)
-                    
-                    HStack(spacing: 4) {
-                        Text(result.isMovie ? "Movie" : "TV Show")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
+                .contentShape(Rectangle())
+            } else {
+                // Design original pour les cartes non-large
+                VStack(alignment: .leading, spacing: 0) {
+                    ZStack(alignment: .bottomLeading) {
+                        KFImage(URL(string: result.fullBackdropURL ?? result.fullPosterURL ?? ""))
+                            .placeholder {
+                                FallbackImageView(
+                                    isMovie: result.isMovie,
+                                    size: CGSize(width: cardWidth, height: cardHeight * 0.75)
+                                )
+                            }
+                            .resizable()
+                            .aspectRatio(16/9, contentMode: .fill)
+                            .frame(width: cardWidth, height: cardHeight * 0.75)
+                            .clipped()
                         
-                        if !result.displayDate.isEmpty {
-                            Text("•")
+                        LinearGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: Color.clear, location: 0.0),
+                                .init(color: Color.black.opacity(0.3), location: 0.5),
+                                .init(color: Color.black.opacity(0.7), location: 1.0)
+                            ]),
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: cardHeight * 0.4)
+                        
+                        VStack {
+                            HStack {
+                                Spacer()
+                                HStack(spacing: 2) {
+                                    Image(systemName: "star.fill")
+                                        .font(.caption2)
+                                        .foregroundColor(.yellow)
+                                    Text(String(format: "%.1f", result.voteAverage ?? 0.0))
+                                        .font(.caption2)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.white)
+                                }
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(Color.black.opacity(0.6))
+                                .clipShape(Capsule())
+                            }
+                            Spacer()
+                        }
+                        .padding(8)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(result.displayTitle)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .lineLimit(1)
+                            .foregroundColor(.primary)
+                        
+                        HStack(spacing: 4) {
+                            Text(result.isMovie ? "Movie" : "TV Show")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
-                            Text(String(result.displayDate.prefix(4)))
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
+                            
+                            if !result.displayDate.isEmpty {
+                                Text("•")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                Text(String(result.displayDate.prefix(4)))
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
+                    .frame(width: cardWidth, alignment: .leading)
+                    .padding(.top, 8)
                 }
-                .frame(width: cardWidth, alignment: .leading)
-                .padding(.top, 8)
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
     }


### PR DESCRIPTION
Unify media type and rating pills styling in hero section:
- Replace inconsistent backgrounds with D9D9D9 50% opacity
- Add ultraThinMaterial blur effect for modern glass appearance
- Improve visual consistency across hero section components

Affected components:
- Media type pill (Movie/TV Series)
- Rating pill (star + vote average)