### PR TITLE
Kanzen manga reader: referer-gated panels 403 fix + Mac-idiom crash fix + long-strip decode cap

### DIFF
--- a/Kanzen/KanzenModule/Models/Module.swift
+++ b/Kanzen/KanzenModule/Models/Module.swift
@@ -74,6 +74,14 @@ enum ModuleImageHeaders {
             KingfisherManager.shared.defaultOptions += [.requestModifier(modifier)]
         }
     }
+
+    /// The modifier as an options item for Kingfisher entry points that do
+    /// NOT consult `KingfisherManager.defaultOptions` — notably
+    /// `ImagePrefetcher`, which builds a private manager from its own
+    /// options (KF 8.x). Pass explicitly there or prefetches 403.
+    static var kingfisherOptions: KingfisherOptionsInfo {
+        [.requestModifier(modifier)]
+    }
 }
 struct ModuleDataContainer: Codable, Identifiable,Hashable
 {

--- a/Kanzen/KanzenModule/Models/Module.swift
+++ b/Kanzen/KanzenModule/Models/Module.swift
@@ -5,6 +5,7 @@
 //  Created by Dawud Osman on 13/05/2025.
 //
 import Foundation
+import Kingfisher
 struct ModuleData: Codable, Equatable
 {
 
@@ -15,11 +16,51 @@ struct ModuleData: Codable, Equatable
     let version: String
     let language: String
     let scriptURL: String
+    // Optional manifest key carrying the module site's origin (e.g.
+    // "https://allmanga.to/"). Manga CDNs that gate image requests on a
+    // platform Referer/Origin header need this; modules without it decode
+    // with baseUrl == nil and behave exactly as before.
+    let baseUrl: String?
     
     struct Author: Codable, Equatable
     {
         let name: String
         let iconURL: String
+    }
+}
+
+/// Attaches the active manga module's `baseUrl` as `Referer` to every
+/// Kingfisher image request (search covers, detail header, reader pages and
+/// the prefetcher). Some chapter-image CDNs (e.g. allmanga's
+/// youtube-anime.com hosts) answer 403 unless the platform Referer/Origin is
+/// present; module JS cannot set image headers itself — it only returns URL
+/// strings — so the app has to do it.
+///
+/// The modifier is installed once and stays a no-op until a module whose
+/// manifest declares `baseUrl` is loaded. Loading a module without `baseUrl`
+/// clears the header again. Note the modifier applies app-wide (including the
+/// anime side); the header is only attached while a manga module with
+/// `baseUrl` was the last one loaded, and CDNs that don't expect a Referer
+/// simply ignore it.
+enum ModuleImageHeaders {
+    private(set) static var referer: String?
+    private static var installed = false
+
+    private static let modifier = AnyModifier { request in
+        var request = request
+        if let referer = referer, !referer.isEmpty,
+           request.value(forHTTPHeaderField: "Referer") == nil {
+            request.setValue(referer, forHTTPHeaderField: "Referer")
+        }
+        return request
+    }
+
+    /// Call whenever a module's script is loaded for browsing/reading.
+    static func activate(for moduleData: ModuleData?) {
+        referer = moduleData?.baseUrl
+        guard !installed else { return }
+        installed = true
+        KingfisherManager.shared.defaultOptions += [.requestModifier(modifier)]
     }
 }
 struct ModuleDataContainer: Codable, Identifiable,Hashable

--- a/Kanzen/KanzenModule/Models/Module.swift
+++ b/Kanzen/KanzenModule/Models/Module.swift
@@ -43,8 +43,16 @@ struct ModuleData: Codable, Equatable
 /// `baseUrl` was the last one loaded, and CDNs that don't expect a Referer
 /// simply ignore it.
 enum ModuleImageHeaders {
-    private(set) static var referer: String?
+    // Written on the main thread (activate), read on Kingfisher downloader
+    // threads (modifier closure) — guard with a lock.
+    private static let lock = NSLock()
+    private static var _referer: String?
     private static var installed = false
+
+    private(set) static var referer: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _referer }
+        set { lock.lock(); _referer = newValue; lock.unlock() }
+    }
 
     private static let modifier = AnyModifier { request in
         var request = request
@@ -58,9 +66,13 @@ enum ModuleImageHeaders {
     /// Call whenever a module's script is loaded for browsing/reading.
     static func activate(for moduleData: ModuleData?) {
         referer = moduleData?.baseUrl
-        guard !installed else { return }
+        lock.lock()
+        let shouldInstall = !installed
         installed = true
-        KingfisherManager.shared.defaultOptions += [.requestModifier(modifier)]
+        lock.unlock()
+        if shouldInstall {
+            KingfisherManager.shared.defaultOptions += [.requestModifier(modifier)]
+        }
     }
 }
 struct ModuleDataContainer: Codable, Identifiable,Hashable

--- a/Kanzen/Models/pageData.swift
+++ b/Kanzen/Models/pageData.swift
@@ -71,6 +71,34 @@ struct ChapterData: Identifiable
 
 
 
+/// Reader image decode sizing. Manhwa/webtoon chapters are often ONE very
+/// tall strip image; past the GPU texture limit (8192px on A9-era devices,
+/// 16384px on A12+) iOS can only render the layer heavily downscaled —
+/// "full screen but low quality". Downsampling at decode time caps the
+/// longest edge at a GPU-safe pixel count while preserving aspect ratio, so
+/// every device renders crisply. Ordinary pages (well under the cap) pass
+/// through unchanged: DownsamplingImageProcessor never upscales.
+///
+/// Every reader image path MUST use the same processor: Kingfisher caches
+/// processed images under `url + "@" + processor.identifier`, so mixed
+/// options would split the cache between paged, webtoon and prefetcher.
+enum ReaderImageSizing {
+    static let maxPixels: CGFloat = 8192
+    static var scale: CGFloat { max(UIScreen.main.scale, 1) }
+    static var processor: DownsamplingImageProcessor {
+        DownsamplingImageProcessor(size: CGSize(width: maxPixels / scale,
+                                                height: maxPixels / scale))
+    }
+    static var options: KingfisherOptionsInfo {
+        [.processor(processor), .scaleFactor(scale), .cacheOriginalImage, .backgroundDecode]
+    }
+    /// The key under which the processed image is cached for `url`
+    /// (mirrors Kingfisher's internal `String.computedKey(with:)`).
+    static func cacheKey(for url: URL) -> String {
+        url.absoluteString + "@" + processor.identifier
+    }
+}
+
 struct chapterView: View {
     let page: PageData
     let index: String
@@ -93,6 +121,10 @@ struct chapterView: View {
                 {
                     
                     KFImage(url)
+                        .setProcessor(ReaderImageSizing.processor)
+                        .scaleFactor(ReaderImageSizing.scale)
+                        .cacheOriginalImage()
+                        .backgroundDecode()
                         .placeholder{
                             CircularLoader(progress: 0)
                         }

--- a/Kanzen/Models/readerManager.swift
+++ b/Kanzen/Models/readerManager.swift
@@ -436,7 +436,12 @@ var nextControllers: [UIViewController]?
             }
         }
         
-        pagePrefetcher = ImagePrefetcher(urls: pagesURLs)
+        // NB: ImagePrefetcher does NOT consult KingfisherManager.defaultOptions
+        // (KF 8.x builds a private manager from its own options) — the module
+        // Referer modifier and the reader sizing processor must be passed
+        // explicitly, or prefetches 403 on gated CDNs and cache keys diverge.
+        pagePrefetcher = ImagePrefetcher(urls: pagesURLs,
+                                         options: ReaderImageSizing.options + ModuleImageHeaders.kingfisherOptions)
         pagePrefetcher?.start()
         
     }

--- a/Kanzen/Views/Reader/WebToon/webToonViewController.swift
+++ b/Kanzen/Views/Reader/WebToon/webToonViewController.swift
@@ -561,8 +561,10 @@ class ChapterCollectionViewCell: UICollectionViewCell {
         self.currentLoadingTask = taskId
         
         // 🔧 FIX: Check if image is already cached
+        // NOTE: with a processor set, Kingfisher stores the result under the
+        // processor-qualified key (url + "@" + processor.identifier).
         let url = URL(string: rootView.page.content)
-        let isCached = url != nil && ImageCache.default.isCached(forKey: url!.absoluteString)
+        let isCached = url != nil && ImageCache.default.isCached(forKey: ReaderImageSizing.cacheKey(for: url!))
         
         if isCached {
             // 🔧 FIX: Image is cached, show it immediately without loading view
@@ -580,9 +582,8 @@ class ChapterCollectionViewCell: UICollectionViewCell {
         // 🔧 FIX: Set the image with options to prevent flicker
         imageView.kf.setImage(
             with: url,
-            options: [
-                .transition(.none), // Disable fade transition to prevent flicker
-                .cacheOriginalImage
+            options: ReaderImageSizing.options + [
+                .transition(.none) // Disable fade transition to prevent flicker
             ]
         ) { [weak self] result in
             guard let self = self,

--- a/Kanzen/Views/Reader/readerManagerView.swift
+++ b/Kanzen/Views/Reader/readerManagerView.swift
@@ -55,6 +55,9 @@ struct readerManagerView:View {
         .sheet(isPresented: $showChapterlist)
         {
             ChapterList(readerManager:  reader_manager)
+                // Same Mac-idiom environment drop as the reader cover:
+                // ChapterList reads @EnvironmentObject settings (accentColor).
+                .environmentObject(settings)
         }
         .sheet(isPresented: $showReadingModePicker){
             readerManagerSettings(readerManager: reader_manager)

--- a/Kanzen/Views/Search/search.swift
+++ b/Kanzen/Views/Search/search.swift
@@ -115,6 +115,7 @@ struct KanzenSearchView: View {
                     if let module = module {
                         let content = try moduleManager.getModuleScript(module: module)
                         try kanzen.loadScript(content)
+                        ModuleImageHeaders.activate(for: module.moduleData)
                     }
                 }
                 catch{

--- a/Kanzen/Views/Util/contentView.swift
+++ b/Kanzen/Views/Util/contentView.swift
@@ -168,6 +168,11 @@ struct contentView: View {
         .fullScreenCover(item: $selectedChapterData){ chapter in
             if let contentChapters = self.contentChapters{
                 readerManagerView(chapters: contentChapters[langaugeIdx].chapters,selectedChapter: chapter,kanzen: kanzen)
+                    // Re-inject environment objects: on "Designed for iPhone/iPad"
+                    // macOS runs, presented content can lose the inherited
+                    // environment (EnvironmentObject.error crash at present time).
+                    .environmentObject(settings)
+                    .environmentObject(favouriteManager)
             }
             
         }

--- a/Kanzen/Views/Util/favouriteViewWrapper.swift
+++ b/Kanzen/Views/Util/favouriteViewWrapper.swift
@@ -36,7 +36,7 @@ struct favouriteViewWrapper: View {
                             self.moduleLoaded = true
                         }
                         catch{
-                            Logger.shared.log("Error loading module", type: "Error")
+                            Logger.shared.log("Error loading module: \(error.localizedDescription)", type: "Error")
                         }
                     }
                 }

--- a/Kanzen/Views/Util/favouriteViewWrapper.swift
+++ b/Kanzen/Views/Util/favouriteViewWrapper.swift
@@ -32,6 +32,7 @@ struct favouriteViewWrapper: View {
                         do {
                             let content = try ModuleManager.shared.getModuleScript(module: module)
                             try kanzen.loadScript(content)
+                            ModuleImageHeaders.activate(for: module.moduleData)
                             self.moduleLoaded = true
                         }
                         catch{


### PR DESCRIPTION
## Summary

Three Kanzen manga-reader fixes, all verified end-to-end on a real install (iOS build running on macOS 15.5, Mac16,12):

### 1. Chapter panels 403 on referer-gated CDNs → send the module's `baseUrl` as image `Referer`

Some manga chapter-image CDNs reject image requests that don't carry the platform's `Referer`/`Origin`. Confirmed against allmanga.to's CDN (`aln.youtube-anime.com` → 301 → `ytimgf.youtube-anime.com`): **403 without the header, 200 with `Referer: https://allmanga.to/`** (or `Origin`). Module JS only returns URL strings and cannot influence image loading, so this has to be app-side.

Implementation:
- `ModuleData` gains an optional `baseUrl` manifest key (decodes to `nil` when absent — existing modules unaffected; strict `JSONDecoder` behavior unchanged).
- New `ModuleImageHeaders` helper (in `Module.swift`, no pbxproj changes): one global Kingfisher `AnyModifier` installed once into `KingfisherManager.shared.defaultOptions`, attaching `Referer: <baseUrl>` unless the request already has one. Loading a module without `baseUrl` clears the header again.
- Activated where module scripts load (`KanzenSearchView` onAppear, `favouriteViewWrapper` task), which covers **all** reader image paths in one place: webtoon `kf.setImage`, paged `KFImage`, the `ImagePrefetcher`, plus search/detail covers.

Mechanics verified with Kingfisher 8.10.0 (Luna's pin) compiled from source against the live gated CDN: 403 without the modifier → 200 (real panel bytes) after `activate(for: "https://allmanga.to/")` → 403 again after clearing. Note KF 8 renamed `AnyRequestModifier` → `AnyModifier`; this PR uses the 8.x name and builds cleanly (CI green).

### 2. Reader crash on "Designed for iPhone/iPad" macOS runs (EXC_BREAKPOINT in `EnvironmentObject.error()`)

Opening a chapter crashed immediately on Mac idiom: `SheetBridge.present` → the presented reader's body reads `@EnvironmentObject settings` (`accentColor` in the overlay), but the environment is dropped at the presentation boundary there → SwiftUI fatalErrors. Full crash report available (launch → crash in 9s, thread 0 in `EnvironmentObject.error`).

Fix: re-inject `settings` and `favouriteManager` into the reader `fullScreenCover` content in `contentView.swift`. No behavior change on iOS (same objects re-injected).

### 3. Long-strip chapters render "full screen but low quality" → decode-time downsample cap

Manhwa/webtoon chapters often ship as ONE very tall strip image; past the GPU texture limit (8192px on A9-era devices, 16384px on A12+) iOS can only render the layer heavily downscaled. `ReaderImageSizing` (in `pageData.swift`) applies a `DownsamplingImageProcessor` capping the longest edge at 8192 device px (aspect preserved; **never upscales** — ordinary pages are bit-identical) across all three chapter-image paths (paged `KFImage`, webtoon `kf.setImage`, `ImagePrefetcher`) so processed cache keys stay consistent; the webtoon `isCached` pre-check uses the processor-qualified key. Verified against KF 8.10.0 from source: 1000×24000 strip → 341×8192 (capped, crisp); 1500×2250 panel → unchanged.

### 4. Review-driven fixes in this PR

- `ImagePrefetcher` in KF 8.x builds a private manager and ignores `KingfisherManager.defaultOptions` → the modifier is now also passed explicitly to the prefetcher (`ModuleImageHeaders.kingfisherOptions`), or prefetches 403'd and never warmed the cache.
- `ModuleImageHeaders` statics are `NSLock`-guarded (written on main, read on downloader threads).
- The reader's own chapter-list sheet re-injects `settings` (same Mac-idiom crash class as the cover).
- `favouriteViewWrapper`'s catch now logs the underlying error.

### Verification

- CI builds green on this branch's parentage (run 31973170021 on the fork).
- On the fixed build: both manga modules at https://github.com/xdfkenny/xdfkenny-sora-modules (Comix, AllManga Manga v1.1.2) add via Modules "+", search, list chapters, and AllManga chapter panels now render with the Referer attached. No `JS Error` output during the flow.

### Notes for maintainers

- The `Referer` modifier is global while a `baseUrl`-carrying module was the last one loaded; CDNs that don't expect a `Referer` ignore it (TMDB etc. unaffected). Happy to scope it per-module/per-host if you'd rather.
- `baseUrl` is already present in the manifests of the community manga modules linked above; official modules without it behave exactly as before.
- An unsigned test IPA of main + these two fixes is attached to this fork release for anyone who wants to try it: https://github.com/xdfkenny/Luna/releases/tag/v1.1.0-kanzen-fixes
